### PR TITLE
Fix previews for dependant styles being needlessly regenerated. #34

### DIFF
--- a/scripts/generate-previews
+++ b/scripts/generate-previews
@@ -82,7 +82,7 @@ foreach ($styles as $style) {
 	$xml = new SimpleXMLElement($style['code']);
 
 	if($xml['default-locale']) {
-		$lookup[$name]['default-locale'] = $xml['default-locale'];
+		$lookup[$name]['default-locale'] = (string) $xml['default-locale'];
 	} else {
 		$lookup[$name]['default-locale'] = FALLBACK_LOCALE;
 	}


### PR DESCRIPTION
Previously, due to invalid check, it would regenerate styles for >4000 dependent styles, now down to ~200.